### PR TITLE
build: stop building kek-win32 on non-Win32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ add_compile_options(-Wall -pedantic -Wextra)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
+if (NOT WIN32)
+
 add_executable(
   kek
   bus.cpp
@@ -34,6 +36,10 @@ add_executable(
   utils.cpp
 )
 
+endif (NOT WIN32)
+
+if (WIN32)
+
 add_executable(
   kek-win32
   bus.cpp
@@ -58,6 +64,8 @@ add_executable(
   win32.cpp
 )
 
+endif (WIN32)
+
 include(CheckIPOSupported)
 check_ipo_supported(RESULT supported)
 
@@ -68,10 +76,13 @@ set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads)
+if (NOT WIN32)
 target_link_libraries(kek Threads::Threads)
+else ()
 target_link_libraries(kek-win32 Threads::Threads)
 
 target_link_libraries(kek-win32 ws2_32)
+endif ()
 
 include(FindPkgConfig)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ To build for e.g. linux:
     mkdir build
     cd build
     cmake ..
-    make kek
+    make
 
     Required:
     * libncursesw5-dev
@@ -16,7 +16,7 @@ To build for e.g. windows:
     mkdir build-win32
     cd build-win32
     cmake -DCMAKE_TOOLCHAIN_FILE=../mingw64.cmake ..
-    make kek-win32
+    make
 
 
 To run a disk image:


### PR DESCRIPTION
The README says to use `make kek`, got it, but if you use just `make` anyway, it tries to build kek-win32, which fails because ncurses flags somehow don't make it to the command line.

```
$ make kek-win32 VERBOSE=1
..
[ 53%] Building CXX object CMakeFiles/kek-win32.dir/main.cpp.o
/usr/bin/c++   -O2 -g -DNDEBUG -std=gnu++17 -Wall -pedantic -Wextra -MD -MT CMakeFiles/kek-win32.dir/main.cpp.o -MF CMakeFiles/kek-win32.dir/main.cpp.o.d -o CMakeFiles/kek-win32.dir/main.cpp.o -c /home/jengelh/code/kek/main.cpp
In file included from /home/jengelh/code/kek/console_ncurses.h:8,
                 from ~/kek/main.cpp:13:
~/kek/terminal.h:8:10: fatal error: panel.h: No such file or directory
    8 | #include <panel.h>
```

Anyway, the right thing to do would appear to just not attempt building of kek-win32 on Linux.